### PR TITLE
Use readystatechange instead of window.load listener

### DIFF
--- a/.karma.cjs
+++ b/.karma.cjs
@@ -6,23 +6,25 @@ module.exports = (config) => {
     const { LOG_INFO: logLevel } = config;
 
     config.set({
+        files: [ file ],
+        basePath: __dirname,
+        customContextFile: join(__dirname, 'integration/context.html'),
+
         browsers: [ 'Chrome' ],
         frameworks: [ 'mocha' ],
+        reporters: [ 'mocha' ],
+        plugins : [
+            require('karma-webpack'),
+            require('karma-chrome-launcher'),
+            require('karma-mocha'),
+            require('karma-mocha-reporter')
+        ],
+        preprocessors: { [file]: [ 'webpack' ] },
+        webpack: {},
+
         port: 9876,
         logLevel,
         singleRun: true,
-        concurrency: 1,
-        hooks : [
-            'karma-webpack',
-            'karma-chrome-launcher',
-            'karma-mocha',
-            'karma-mocha-reporter'
-        ],
-        reporters: [ 'mocha' ],
-        basePath: __dirname,
-        customContextFile: join(__dirname, 'integration/context.html'),
-        files: [ file ],
-        preprocessors: { [file]: [ 'webpack' ] },
-        webpack: {}
+        concurrency: 1
     });
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# 1.0.0
+_2021-04-07_
+
+## New Feature
+Pass a callback function to "register" to catch the error instead of it being thrown on the page.
+
+## Improvement
+Use readystatechange exclusively for load listeners (replace window load).
+
+## Misc
+Graduate to stable release.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # failed-to-load
-Find script tags that have failed to load before `window.load`.
+Find script tags that have failed to load when document's readyState is complete.
 
 Add this attribute "onload" with "this.loaded=1" in its value (`onload="this.loaded=1"`)
 ```html
@@ -26,6 +26,13 @@ This will throw an ayncronous error to be caught by your global onerror callback
 >   ]
 > }
 > ```
+
+Alternatively, you can register a callback to catch the error (then it will not be thrown)
+```js
+register(
+  error => logger.warn(error)
+);
+```
 
 Check and report manually:
 ```js

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import check from './src/check';
-import register from './src/register';
+import check from './src/check/index.js';
+import register from './src/register/index.js';
 
 export { check, register };

--- a/integration/test.js
+++ b/integration/test.js
@@ -10,6 +10,18 @@ const { onerror } = window;
 const errors = [];
 let readyState;
 
+function updateReadyState(readyState) {
+    Object.defineProperty(
+        document,
+        'readyState',
+        {
+            value: readyState,
+            writable: true
+        }
+    );
+    document.dispatchEvent(new Event('readystatechange'));
+}
+
 describe('Throws errors when script tags are not loaded', () => {
     beforeEach(() => {
         window.onerror = (message, file, line, column, error) => {
@@ -23,7 +35,7 @@ describe('Throws errors when script tags are not loaded', () => {
     afterEach(() => {
         errors.length = 0;
         window.onerror = onerror;
-        Object.defineProperty(document, 'readyState', { value: readyState, writable: true });
+        updateReadyState(readyState);
     });
     it('should throw relevant error on the window context', async() => {
         register();
@@ -69,20 +81,31 @@ describe('Throws errors when script tags are not loaded', () => {
         expect(message).to.match(/http:\/\/localhost:\d{4}\/one\/missing\.js/m);
         expect(message).to.match(/http:\/\/localhost:\d{4}\/other\/missing\.js/m);
     });
-    it('should register for window load when document is not ready', async() => {
-        Object.defineProperty(document, 'readyState', { value: 'loading', writable: true });
+    it('should register for document readystatechange when document is not ready', async() => {
+        updateReadyState('loading');
         register();
         await wait(100);
         expect(errors).to.have.lengthOf(0);
-        window.dispatchEvent(new Event('load'));
+        updateReadyState('complete');
         await wait(100);
         expect(errors).to.have.lengthOf(1);
     });
     it('should trigger on next tick when document is ready', async() => {
-        Object.defineProperty(document, 'readyState', { value: 'complete', writable: true });
+        updateReadyState('complete');
         register();
         expect(errors).to.have.lengthOf(0);
         await wait(0);
         expect(errors).to.have.lengthOf(1);
+    });
+    it('should trigger callback instead of throwing an error', async() => {
+        updateReadyState('complete');
+        const callbackError = [];
+        register(
+            (error) => callbackError.push(error)
+        );
+        expect(errors).to.have.lengthOf(0);
+        await wait(0);
+        expect(errors).to.have.lengthOf(0);
+        expect(callbackError).to.have.lengthOf(1);
     });
 });

--- a/integration/test.js
+++ b/integration/test.js
@@ -1,8 +1,8 @@
 import chai from 'chai';
 import chaiString from 'chai-string';
 import wait from '@lets/wait';
-import { register } from '..';
-import { code, message } from '../src/consts';
+import { register } from '../index.js';
+import { code, message } from '../src/consts/index.js';
 
 chai.use(chaiString);
 const { expect } = chai;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "failed-to-load",
   "version": "1.0.0",
-  "description": "Find script tag that have failed to load before window.load",
+  "description": "Find script tag that have failed to load when document's readyState is complete",
   "tags": [
     "script",
     "script tag",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "failed-to-load",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Find script tag that have failed to load before window.load",
   "tags": [
     "script",
@@ -23,23 +23,27 @@
   },
   "author": "Fiverr SRE",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fiverr/failed-to-load.git"
+  },
   "devDependencies": {
-    "@fiverr/eslint-config-fiverr": "^3.2.1",
+    "@fiverr/eslint-config-fiverr": "^3.2.2",
     "@lets/wait": "^2.0.2",
-    "@rollup/plugin-commonjs": "^15.1.0",
-    "@rollup/plugin-node-resolve": "^9.0.0",
+    "@rollup/plugin-commonjs": "^17.0.0",
+    "@rollup/plugin-node-resolve": "^11.0.0",
     "chai": "^4.2.0",
     "chai-string": "^1.5.0",
-    "eslint": "^7.10.0",
+    "eslint": "^7.14.0",
     "eslint-plugin-log": "^1.2.6",
     "karma": "^5.2.3",
     "karma-chrome-launcher": "^3.1.0",
     "karma-cli": "^2.0.0",
-    "karma-firefox-launcher": "^1.3.0",
+    "karma-firefox-launcher": "^2.1.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-webpack": "^4.0.2",
-    "mocha": "^8.1.3",
+    "mocha": "^8.2.1",
     "webpack": "^4.44.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,18 +32,18 @@
     "@lets/wait": "^2.0.2",
     "@rollup/plugin-commonjs": "^17.0.0",
     "@rollup/plugin-node-resolve": "^11.0.0",
-    "chai": "^4.2.0",
+    "chai": "^4.3.4",
     "chai-string": "^1.5.0",
-    "eslint": "^7.14.0",
-    "eslint-plugin-log": "^1.2.6",
-    "karma": "^5.2.3",
+    "eslint": "^7.23.0",
+    "eslint-plugin-log": "^1.2.7",
+    "karma": "^6.3.2",
     "karma-chrome-launcher": "^3.1.0",
     "karma-cli": "^2.0.0",
     "karma-firefox-launcher": "^2.1.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
-    "karma-webpack": "^4.0.2",
-    "mocha": "^8.2.1",
-    "webpack": "^4.44.2"
+    "karma-webpack": "^5.0.0",
+    "mocha": "^8.3.2",
+    "webpack": "^5.30.0"
   }
 }

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -2,19 +2,27 @@ import check from '../check/index.js';
 import { code, message } from '../consts/index.js';
 
 /**
- * Register "checkAndThrow" function to the `window.load` event.
+ * Call "checkAndThrow" only when document's readyState is complete.
+ * @param {function} callback
+ * @returns {undefined}
  */
-export default function register() {
+export default function register(callback) {
     document.readyState === 'complete'
-        ? checkAndThrow()
-        : window.addEventListener('load', checkAndThrow);
+        ? checkAndThrow(callback)
+        : document.addEventListener(
+            'readystatechange',
+            () => register(callback),
+            { once: true }
+        );
 }
 
 /**
  * Belated execution of the check and error throwing
  * Throws the error globally (potentially).
+ * @param {function} callback
+ * @returns {undefined}
  */
-function checkAndThrow() {
+function checkAndThrow(callback) {
 
     // Check and throw on next tick
     setTimeout(() => {
@@ -37,7 +45,11 @@ function checkAndThrow() {
                 code: error.code
             });
 
-            throw error;
+            if (typeof callback === 'function') {
+                callback(error);
+            } else {
+                throw error;
+            }
         }
     });
 }

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -2,13 +2,13 @@ import check from '../check/index.js';
 import { code, message } from '../consts/index.js';
 
 /**
- * Call "checkAndThrow" only when document's readyState is complete.
+ * Call "checkAndErr" only when document's readyState is complete.
  * @param {function} callback
  * @returns {undefined}
  */
 export default function register(callback) {
     document.readyState === 'complete'
-        ? checkAndThrow(callback)
+        ? checkAndErr(callback)
         : document.addEventListener(
             'readystatechange',
             () => register(callback),
@@ -22,34 +22,34 @@ export default function register(callback) {
  * @param {function} callback
  * @returns {undefined}
  */
-function checkAndThrow(callback) {
+function checkAndErr(callback) {
 
     // Check and throw on next tick
     setTimeout(() => {
         const files = check();
 
-        if (files.length) {
-            const error = new Error(
-                [
-                    message,
-                    ...files.map(
-                        ({ src }) => src
-                    )
-                ].join('\n')
-            );
-            error.code = code;
-            error.files = files;
+        if (!files.length) { return; }
 
-            error.toJSON = () => ({
-                message: error.message,
-                code: error.code
-            });
+        const error = new Error(
+            [
+                message,
+                ...files.map(
+                    ({ src }) => src
+                )
+            ].join('\n')
+        );
+        error.code = code;
+        error.files = files;
 
-            if (typeof callback === 'function') {
-                callback(error);
-            } else {
-                throw error;
-            }
+        error.toJSON = () => ({
+            message: error.message,
+            code: error.code
+        });
+
+        if (typeof callback === 'function') {
+            callback(error);
+        } else {
+            throw error;
         }
     });
 }

--- a/src/register/index.js
+++ b/src/register/index.js
@@ -2,13 +2,13 @@ import check from '../check/index.js';
 import { code, message } from '../consts/index.js';
 
 /**
- * Call "checkAndErr" only when document's readyState is complete.
+ * Call "createError" only when document's readyState is complete.
  * @param {function} callback
  * @returns {undefined}
  */
 export default function register(callback) {
     document.readyState === 'complete'
-        ? checkAndErr(callback)
+        ? createError(callback)
         : document.addEventListener(
             'readystatechange',
             () => register(callback),
@@ -22,7 +22,7 @@ export default function register(callback) {
  * @param {function} callback
  * @returns {undefined}
  */
-function checkAndErr(callback) {
+function createError(callback) {
 
     // Check and throw on next tick
     setTimeout(() => {


### PR DESCRIPTION
- Use readystatechange instead of window.load in order to check and register to the same topic
- Add the ability to pass to "register" a callback function instead of it throwing an error on window
- Graduate to a semver